### PR TITLE
update keepalive config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -126,9 +126,9 @@ impl Default for ControllerConfig {
             wal_path: "./data/wal_chain".to_string(),
             send_chain_status_interval_sync: 1000,
             health_check_timeout: 300,
-            http2_keepalive_interval: 60,
-            http2_keepalive_timeout: 20,
-            tcp_keepalive: 60,
+            http2_keepalive_interval: 300,
+            http2_keepalive_timeout: 10,
+            tcp_keepalive: 600,
             enable_metrics: true,
             metrics_port: 60004,
             metrics_buckets: vec![


### PR DESCRIPTION
keepalive参数最好是客户端和服务端保持一致。
经过讨论，将参数定为http2层面的keep alive interval 5分钟，timeout 10s。tcp层面的keepalive设置为10分钟。